### PR TITLE
⭐ Duplication Fix.

### DIFF
--- a/commands/economy/gamble.js
+++ b/commands/economy/gamble.js
@@ -27,6 +27,7 @@ module.exports = {
                 .addField('Ok, if you roll an even number you win, if you roll an odd number, you lose.', '_')
                 .setTimestamp()
                 .setFooter('Grape Gambling Club.');
+            d.addMoni(message.author.id, -bet);
             message.channel.send(gambleEmbed)
                 .then((msg) => {
                     setTimeout(function () {
@@ -36,11 +37,10 @@ module.exports = {
                                     setTimeout(function () {
                                         if (diceRoll % 2 === 0) {
                                             msg.edit(gambleEmbed.addField(`Congrats, you get ${bet} :star:s!`, '_'));
-                                            d.addMoni(message.author.id, bet);
+                                            d.addMoni(message.author.id, bet*2);
                                         }
                                         else {
                                             msg.edit(gambleEmbed.addField(`Rip, you lost your ${bet} :star:s.`, '_'));
-                                            d.addMoni(message.author.id, -bet);
                                         }
                                         if (inv && inv["rigged dice"] && Math.floor(Math.random() * 50) + 1 === 1) {
                                             setTimeout(function () { busted(bet); }, 1700)
@@ -70,10 +70,11 @@ module.exports = {
                 time: 8000,
                 errors: ['time']
             })
-                .then(message => {
+                .then(async message => {
                     message = message.first()
                     if (message.content.toLowerCase() === 'yes' || message.content.toLowerCase() === 'y') {
-                        decideFate(userBal);
+                        let newBal = await d.users.get(message.author.id);
+                        decideFate(newBal);
                     } else if (message.content.toLowerCase() === 'no' || message.content.toLowerCase() === 'n') {
                         message.channel.send('ok then')
                     }


### PR DESCRIPTION
In the unedited version the gamble command will only remove stars after a 6.9 second delay. During this time you can transfer them to another account which means you won't have any stars to lose. I also fixed a separate bug with +gamble all where the number of stars you bet is gathered before the confirmation. With this issue the user could gamble all, switch to another channel, pay all their money to an alt, then confirm the gamble all to gamble with no risk. I suspect +rr all and +bj all have the same issue, those need to be fixed also if so.