### PR TITLE
Fix Pickaxe Breakage RNG

### DIFF
--- a/src/commands/economy/dig.js
+++ b/src/commands/economy/dig.js
@@ -71,7 +71,7 @@ module.exports =
                     if (super.randomize(prob[entry]) + 1 === 1) await choose(+entry + 1, amts[entry]);
                 }
 
-                if (super.randomize(prob[3]) + 1 === 1) {
+                if (super.randomize(prob[4]) + 1 === 1) {
                     mineEmbed.addField("Uh oh!", "Your pickaxe broke, buy a new one from the shop!");
                     await this.eco.items.deleteItem(msg.author.id, pickaxe);
                 }


### PR DESCRIPTION
Previously, the chances of pickaxes breaking were as follows

T1: 1/2
T2: 1/35
T3: 1/7
Rainbonite: 1/4

This does not make any sense. This PR will restore the chances to the original (lots of commits ago) chances of

T1: 1/25
T2: 1/50
T3: 1/100
Rainbonite: 1/150